### PR TITLE
remove `StringableCollectionElement` trait definition

### DIFF
--- a/my_utils.mojo
+++ b/my_utils.mojo
@@ -1,6 +1,3 @@
-trait StringableCollectionElement(Stringable, CollectionElement):
-    pass
-
 fn print_v[T: StringableCollectionElement](values: List[T]):
     for v in values:
         print(v[], end="|")


### PR DESCRIPTION
Mojo has `StringableCollectionElement` now.

Here's a run of `quick_sort_sample.mojo`, which uses `printv()`, after removal of the trait definition:

<img width="618" alt="image" src="https://github.com/mzaks/mojo-sort/assets/5898931/ca28b189-fd26-497d-beec-d768f716302d">
